### PR TITLE
Fix line break syntax in IntroCard component

### DIFF
--- a/src/IntroCard.tsx
+++ b/src/IntroCard.tsx
@@ -5,7 +5,7 @@ const IntroCard = () => {
         Josh Lawrence
       </h2>
       <h3 className="pb-2 text-left text-lg text-neutral-400">
-        Senior Cloud Architect,<br>
+        Senior Cloud Architect,<br/>
         DevOps @ Quadax Inc.
       </h3>
       <div className="flex flex-col gap-2">


### PR DESCRIPTION
apparently jsx requires a closing tag for br even though its not applicable at the html level